### PR TITLE
Prepare handling of truncated distribution for changes in Distributions

### DIFF
--- a/src/distributions_ext.jl
+++ b/src/distributions_ext.jl
@@ -439,19 +439,16 @@ Thanks, dude!
 """
 function truncmean(Dist::Truncated)
     F(x) = x*pdf(Dist,x)
-    y = 0.0;
-
+    lower, upper = extrema(Dist)
     if typeof(Dist) <: ContinuousDistribution # Continuous distribution
-        y = quadgk(F, Dist.lower, Dist.upper)[1]
-
+        y = quadgk(F, lower, upper)[1]
     else # Discrete distriubtion
-        x = ceil(Dist.lower)
+        x = ceil(lower)
         q_max = 1 - 1E-9;
-        x_max = min(Dist.upper, quantile(Dist.untruncated, q_max))
-
-        while x < x_max
+        x_max = min(upper, quantile(Dist.untruncated, q_max))
+        y = F(x)
+        while (x += 1) <= x_max
             y += F(x)
-            x += 1
         end
     end
     return y


### PR DESCRIPTION
After https://github.com/JuliaStats/Distributions.jl/pull/1720, fields `lower` and `upper` of a `Truncated` distribution may be `nothing`. These fields are not part of the official API (as `untruncated` as well) and hence can change in any non-breaking release. A search on JuliaHub revealed that this package will be affected by the change in Distributions, and hence I opened a PR that would fix these problems.